### PR TITLE
Added workflow schedule to validate N4A github action

### DIFF
--- a/.github/workflows/testNginxForAzureDeploy.yml
+++ b/.github/workflows/testNginxForAzureDeploy.yml
@@ -1,0 +1,43 @@
+# File: .github/workflows/testNginxForAzureDeploy.yml
+
+name: Test Github action to update NGINX for Azure configurations
+on:
+  schedule:
+    - cron:  '0 20 * * *'
+
+env:
+  NGINX_DEPLOYMENT_NAME: githhubci-test-dep
+  NGINX_CONFIG_FILE: test/configs/nginx.conf
+  TEST_RESOURCE_GROUP_NAME: testenv-0da38993-workload
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  Update-NGINX-Configuration:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Checkout repository'
+      uses: actions/checkout@v2
+    - name: 'Update config'
+      shell: bash
+      run: |
+        sed -i 's/000000/'"$GITHUB_RUN_ID"'/g' $NGINX_CONFIG_FILE
+    - name: 'AZ CLI Login'
+      uses: azure/login@v1
+      with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: 'Sync NGINX configuration to NGINX on Azure instance'
+      uses: nginxinc/nginx-for-azure-deploy-action@v0
+      with:
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        resource-group-name: $TEST_RESOURCE_GROUP_NAME
+        nginx-deployment-name: $NGINX_DEPLOYMENT_NAME
+        nginx-config-relative-file-path: $NGINX_CONFIG_FILE
+    - name: 'Validate config update'
+      shell: bash
+      run: |
+        wget -O - -o /dev/null http://${{ secrets.NGINX_DEPLOYMENT_IP }} | jq '.request.headers."Github-Run-Id"  | test( "'"$GITHUB_RUN_ID"'")'

--- a/test/configs/nginx.conf
+++ b/test/configs/nginx.conf
@@ -1,0 +1,26 @@
+http {
+    upstream app {
+        zone app 64k;
+        least_conn;
+        server 10.0.1.4:8000;
+    }
+
+    server {
+        listen 80;
+        server_name *.example.com;
+
+        location / {
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Proxy-App app;
+            proxy_set_header Github-Run-Id 000000;
+            proxy_buffering on;
+            proxy_buffer_size 4k;
+            proxy_buffers 8 8k;
+            proxy_read_timeout 60s;
+            proxy_pass http://app;
+            health_check;
+        }
+        
+    }
+}


### PR DESCRIPTION
Passing pipeline! https://github.com/nginxinc/nginx-for-azure-deploy-action/runs/6360067788

Schedule is set to run once a day. We can run it on every push to a open MR if necessary in the future.