### PR TITLE
Support sync multiple files NGINX configuration to an NGINX for Azure deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following example updates the configuration of a NGINX deployment in Azure e
 ```yaml
 # File: .github/workflows/nginxForAzureDeploy.yml
 
-name: Sync configuration to NGINX for Azure 
+name: Sync the NGINX configuration from the Git repository to an NGINX for Azure deployment
 on:
   push:
     branches:
@@ -31,13 +31,15 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    - name: 'Sync NGINX configuration to NGINX on Azure instance'
+    - name: 'Sync the NGINX configuration from the Git repository to the NGINX for Azure deployment'
       uses: nginxinc/nginx-for-azure-deploy-action@v1
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         resource-group-name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
         nginx-deployment-name: ${{ secrets.NGINX_DEPLOYMENT_NAME }}
-        nginx-config-relative-file-path: ${{ secrets.NGINX_CONFIG_FILE }}
+        nginx-config-directory-path: config
+        nginx-root-config-file-name: nginx.conf
+        transformed-nginx-config-directory-path: /etc/nginx
 ```
 
 ### Sample workflow that authenticates with Azure using OIDC
@@ -45,7 +47,7 @@ jobs:
 ```yaml
 # File: .github/workflows/nginxForAzureDeploy.yml
 
-name: Sync configuration to NGINX for Azure 
+name: Sync the NGINX configuration from the Git repository to an NGINX for Azure deployment
 on:
   push:
     branches:
@@ -71,11 +73,13 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: 'Sync NGINX configuration to NGINX on Azure instance'
+    - name: 'Sync the NGINX configuration from the Git repository to the NGINX for Azure deployment'
       uses: nginxinc/nginx-for-azure-deploy-action@v1
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         resource-group-name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
         nginx-deployment-name: ${{ secrets.NGINX_DEPLOYMENT_NAME }}
-        nginx-config-relative-file-path: ${{ secrets.NGINX_CONFIG_FILE }}
+        nginx-config-directory-path: config
+        nginx-root-config-file-name: nginx.conf
+        transformed-nginx-config-directory-path: /etc/nginx
 ```

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         resource-group-name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
         nginx-deployment-name: ${{ secrets.NGINX_DEPLOYMENT_NAME }}
-        nginx-config-directory-path: config
-        nginx-root-config-file-name: nginx.conf
-        transformed-nginx-config-directory-path: /etc/nginx
+        nginx-config-directory-path: config/
+        nginx-root-config-file: nginx.conf
+        transformed-nginx-config-directory-path: /etc/nginx/
 ```
 
 ### Sample workflow that authenticates with Azure using OIDC
@@ -79,7 +79,7 @@ jobs:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         resource-group-name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
         nginx-deployment-name: ${{ secrets.NGINX_DEPLOYMENT_NAME }}
-        nginx-config-directory-path: config
-        nginx-root-config-file-name: nginx.conf
-        transformed-nginx-config-directory-path: /etc/nginx
+        nginx-config-directory-path: config/
+        nginx-root-config-file: nginx.conf
+        transformed-nginx-config-directory-path: /etc/nginx/
 ```

--- a/action.yml
+++ b/action.yml
@@ -11,17 +11,16 @@ inputs:
     description: 'The name of the NGINX for Azure deployment.'
     required: true
   nginx-config-directory-path:
-    description: 'The NGINX configuration directory path relative to the root of the Git repository, example: "config".'
+    description: 'The NGINX configuration directory path relative to the root of the Git repository, example: "config/".'
     required: true
-  nginx-root-config-file-name:
+  nginx-root-config-file:
     description: >
-     'The root NGINX configuration file name, example: "nginx.conf". The root file must be in the NGINX configuration directory 
-     but not in its subdirectory.'
+     'The root NGINX configuration file path relative to the NGINX configuration directory in the Git repository, example: "nginx.conf".'
     required: false
     default: 'nginx.conf'
   transformed-nginx-config-directory-path:
     description: >
-     'The transformed absolute path of the NGINX configuration directory in NGINX for Azure deployment, example: "/etc/nginx". 
+     'The transformed absolute path of the NGINX configuration directory in NGINX for Azure deployment, example: "/etc/nginx/". 
      If the "include" directive in the NGINX configuration files uses absolute paths, the path transformation 
      can be used to overwrite the file paths when the action synchronizes the files to the NGINX for Azure deployment.'
     required: false
@@ -30,5 +29,5 @@ runs:
   using: "composite"
   steps:
     - name: 'Synchronize NGINX configuration from the Git repository to an NGINX for Azure deployment'
-      run: ${{github.action_path}}/src/deploy-config.sh ${{ inputs.subscription-id }} ${{ inputs.resource-group-name }} ${{ inputs.nginx-deployment-name }} ${{ inputs.nginx-config-directory-path }} ${{ inputs.nginx-root-config-file-name }} ${{ inputs.transformed-nginx-config-directory-path }}
+      run: ${{github.action_path}}/src/deploy-config.sh ${{ inputs.subscription-id }} ${{ inputs.resource-group-name }} ${{ inputs.nginx-deployment-name }} ${{ inputs.nginx-config-directory-path }} ${{ inputs.nginx-root-config-file }} ${{ inputs.transformed-nginx-config-directory-path }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,22 +1,34 @@
 name: 'NGINX configuration sync'
-description: 'The action synchronizes NGINX configuration from a Git repository to an NGINX deployment on Azure.'
+description: 'The action synchronizes NGINX configuration from a Git repository to an NGINX for Azure deployment.'
 inputs:
   subscription-id:
-    description: 'The Azure subscription ID of the NGINX deployment'
+    description: 'The Azure subscription ID of the NGINX for Azure deployment.'
     required: true
   resource-group-name:
-    description: 'The resource group of the NGINX deployment'
+    description: 'The resource group of the NGINX for Azure deployment.'
     required: true
   nginx-deployment-name:
-    description: 'The name of the NGINX deployment'
+    description: 'The name of the NGINX for Azure deployment.'
     required: true
-  nginx-config-relative-file-path:
-    description: 'The relative file path of the NGINX configuration file in the Git repository'
+  nginx-config-directory-path:
+    description: 'The NGINX configuration directory path relative to the root of the Git repository, example: "config".'
     required: true
-    default: './config/nginx.conf'
+  nginx-root-config-file-name:
+    description: >
+     'The root NGINX configuration file name, example: "nginx.conf". The root file must be in the NGINX configuration directory 
+     but not in its subdirectory.'
+    required: false
+    default: 'nginx.conf'
+  transformed-nginx-config-directory-path:
+    description: >
+     'The transformed absolute path of the NGINX configuration directory in NGINX for Azure deployment, example: "/etc/nginx". 
+     If the "include" directive in the NGINX configuration files uses absolute paths, the path transformation 
+     can be used to overwrite the file paths when the action synchronizes the files to the NGINX for Azure deployment.'
+    required: false
+    default: ''
 runs:
   using: "composite"
   steps:
-    - name: 'Deploy configuration to the NGINX deployment in Azure'
-      run: ${{github.action_path}}/src/deploy-config.sh ${{ inputs.subscription-id }} ${{ inputs.resource-group-name }} ${{ inputs.nginx-deployment-name }} ${{ inputs.nginx-config-relative-file-path }}
+    - name: 'Synchronize NGINX configuration from the Git repository to an NGINX for Azure deployment'
+      run: ${{github.action_path}}/src/deploy-config.sh ${{ inputs.subscription-id }} ${{ inputs.resource-group-name }} ${{ inputs.nginx-deployment-name }} ${{ inputs.nginx-config-directory-path }} ${{ inputs.nginx-root-config-file-name }} ${{ inputs.transformed-nginx-config-directory-path }}
       shell: bash

--- a/src/deploy-config.sh
+++ b/src/deploy-config.sh
@@ -7,7 +7,7 @@ resource_group_name=$2
 nginx_deployment_name=$3
 config_dir_path=$4
 root_config_file_name=$5
-transformed_config_dir_path=$6
+transformed_config_dir_path=${6:-''}
 
 # Validation and preprocessing
 

--- a/src/deploy-config.sh
+++ b/src/deploy-config.sh
@@ -2,41 +2,91 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-subscriptionId=$1
-resourceGroupName=$2
-nginxDeploymentName=$3
-nginxConfigurationFile=$4
+subscription_id=$1
+resource_group_name=$2
+nginx_deployment_name=$3
+config_dir_path=$4
+root_config_file_name=$5
+transformed_config_dir_path=$6
 
-# Read and encode the NGINX configuration file content.
-if [ -f "$nginxConfigurationFile" ]
+# Validation and preprocessing
+
+if [[ "$config_dir_path" = /* ]]
 then
-    echo "The NGINX configuration file was found."
+    echo "The NGINX configuration directory path in the repository '$config_dir_path' must be a relative path."
+    exit 2
+elif [[ ! "$config_dir_path" = */ ]]
+then
+    echo "The NGINX configuration directory path '$config_dir_path' does not end with '/'. Appending a trailing '/'."
+    config_dir_path="$config_dir_path/"
+fi
+
+if [[ -d "$config_dir_path" ]]
+then
+    echo "The NGINX configuration directory '$config_dir_path' was found."
 else 
-    echo "The NGINX configuration file $nginxConfigurationFile does not exist."
+    echo "The NGINX configuration directory '$config_dir_path' does not exist."
     exit 2
 fi
 
-encodedConfigContent=$(base64 "$nginxConfigurationFile")
-echo "Base64 encoded NGINX configuration content"
-echo "$encodedConfigContent"
+root_config_file_path="$config_dir_path$root_config_file_name"
+if [[ -f "$root_config_file_path" ]]
+then
+    echo "The root NGINX configuration file '$root_config_file_path' was found."
+else 
+    echo "The root NGINX configuration file '$root_config_file_path' does not exist."
+    exit 2
+fi
+
+if [[ ! -z "$transformed_config_dir_path" ]]
+then
+    if [[ ! "$transformed_config_dir_path" = /* ]]
+    then
+        echo "The specified transformed NGINX configuration directory path '$transformed_config_dir_path' must be an absolute path that starts with '/'."
+        exit 2
+    elif [[ ! "$transformed_config_dir_path" = */ ]]
+    then
+        echo "The specified transformed NGINX configuration directory path '$transformed_config_dir_path' does not end with '/'. Appending a trailing '/'."
+        transformed_config_dir_path="$transformed_config_dir_path/"
+    fi
+fi
+
+transformed_root_config_file_path="$transformed_config_dir_path$root_config_file_name"
+echo "The transformed root NGINX configuration file path is '$transformed_root_config_file_path'."
+
+# Create a NGINX configuration tarball.
+
+config_tarball="nginx-config.tar.gz"
+
+echo "Creating a tarball from the NGINX configuration directory."
+tar -cvzf "$config_tarball" -C "$config_dir_path" --xform s:'./':"$transformed_config_dir_path": .
+echo "Successfully created the tarball from the NGINX configuration directory."
+
+echo "Listing the NGINX configuration file paths in the tarball."
+tar -tf "$config_tarball"
+
+encoded_config_tarball=$(base64 "$config_tarball")
+echo "The base64 encoded NGINX configuration tarball"
+echo "$encoded_config_tarball"
 echo ""
 
-# Deploy the configuration to the NGINX instance on Azure using an ARM template.
+# Synchronize the NGINX configuration tarball to the NGINX for Azure deployment.
+
 uuid="$(cat /proc/sys/kernel/random/uuid)"
-templateFile="template-$uuid.json"
-templateDeploymentName="${nginxDeploymentName:0:20}-$uuid"
+template_file="template-$uuid.json"
+template_deployment_name="${nginx_deployment_name:0:20}-$uuid"
 
 wget -O "$templateFile" https://raw.githubusercontent.com/nginxinc/nginx-for-azure-deploy-action/main/src/nginx-for-azure-configuration-template.json
-echo "Downloaded the ARM template for deploying NGINX configuration"
-cat "$templateFile"
+echo "Downloaded the ARM template for synchronizing NGINX configuration."
+cat "$template_file"
 echo ""
 
-echo "Deploying NGINX configuration"
-echo "Subscription: $subscriptionId"
-echo "Resource group: $resourceGroupName"
-echo "NGINX deployment name: $nginxDeploymentName"
-echo "Template deployment name: $templateDeploymentName"
+echo "Synchronizing NGINX configuration"
+echo "Subscription ID: $subscription_id"
+echo "Resource group name: $resource_group_name"
+echo "NGINX for Azure deployment name: $nginx_deployment_name"
+echo "ARM template deployment name: $template_deployment_name"
 echo ""
 
-az account set -s "$subscriptionId" --verbose
-az deployment group create --name "$templateDeploymentName" --resource-group "$resourceGroupName" --template-file "$templateFile" --parameters nginxDeploymentName="$nginxDeploymentName" rootConfigContent="$encodedConfigContent" --verbose
+az account set -s "$subscription_id" --verbose
+az deployment group create --name "$template_deployment_name" --resource-group "$resource_group_name" --template-file "$template_file" --parameters nginxDeploymentName="$nginx_deployment_name" rootFile="$transformed_root_config_file_path" tarball="$encoded_config_tarball" --verbose

--- a/src/deploy-config.sh
+++ b/src/deploy-config.sh
@@ -35,7 +35,8 @@ then
     exit 1
 fi
 
-root_config_file=$(echo $root_config_file | sed 's:^\.\/*::')
+# Remove the leading './' from the root configuration file path if any.
+root_config_file=${root_config_file/#'./'/}
 
 root_config_file_repo_path="$config_dir_path$root_config_file"
 if [[ -f "$root_config_file_repo_path" ]]

--- a/src/deploy-config.sh
+++ b/src/deploy-config.sh
@@ -38,7 +38,7 @@ else
     exit 2
 fi
 
-if [[ ! -z "$transformed_config_dir_path" ]]
+if [[ -n "$transformed_config_dir_path" ]]
 then
     if [[ ! "$transformed_config_dir_path" = /* ]]
     then
@@ -76,7 +76,7 @@ uuid="$(cat /proc/sys/kernel/random/uuid)"
 template_file="template-$uuid.json"
 template_deployment_name="${nginx_deployment_name:0:20}-$uuid"
 
-wget -O "$templateFile" https://raw.githubusercontent.com/nginxinc/nginx-for-azure-deploy-action/main/src/nginx-for-azure-configuration-template.json
+wget -O "$template_file" https://raw.githubusercontent.com/nginxinc/nginx-for-azure-deploy-action/main/src/nginx-for-azure-configuration-template.json
 echo "Downloaded the ARM template for synchronizing NGINX configuration."
 cat "$template_file"
 echo ""

--- a/src/nginx-for-azure-configuration-template.json
+++ b/src/nginx-for-azure-configuration-template.json
@@ -5,20 +5,20 @@
         "nginxDeploymentName": {
             "type": "string",
             "metadata": {
-                "description": "The name of the NGINX deployment resource to deploy the configuration."
+                "description": "The name of the NGINX for Azure deployment to synchronize the configuration."
             }
         },
-        "rootConfigFilePath": {
+        "rootFile": {
             "type": "string",
             "defaultValue": "nginx.conf",
             "metadata": {
-                "description": "The file path of the root NGINX configuration file"
+                "description": "The file path of the root NGINX configuration file."
             }
         },
-        "rootConfigContent": {
+        "tarball": {
             "type": "string",
             "metadata": {
-                "description": "The based64 encoded content of the root NGINX configuration file"
+                "description": "The based64 encoded NGINX configuration tarball."
             }
         }
     },
@@ -29,13 +29,10 @@
             "apiVersion": "2021-05-01-preview",
             "name": "[concat(parameters('nginxDeploymentName'), '/default')]",
             "properties": {
-                "rootFile": "[parameters('rootConfigFilePath')]",
-                "files": [
-                    {
-                        "content": "[parameters('rootConfigContent')]",
-                        "virtualPath": "[parameters('rootConfigFilePath')]"
-                    }
-                ]
+                "rootFile": "[parameters('rootFile')]",
+                "package": {
+                    "data": "[parameters('tarball')]"
+                }
             }
         }
     ]


### PR DESCRIPTION
The change enables the action to support sync multiple files NGINX config to NGINX for Azure by:

1. Packaging the NGINX config directory in the Git repo to a tarball.
2. Optionally, overwrite the paths of the config files in the directory on-the-fly during packaging based on a user provided "transformed" absolute path. This allows users to explicitly specify the "directory path" in NGINX for Azure deployment if the NGINX configuration files use absolute path in "include" directive.
3. Upload the tarball to an NGINX for Azure deployment using ARM template deployment.

**Challenges**
1. Git action workflow agents check out the repo source code in an arbitary working space directory and we don't have control on its path.
2. Users might use either relative (to NGINX prefix path) or absolute paths for "include" directives in their existing NGINX config files.

**Solution**
To overcome the above challenges, file path transformation is required when pack the config directory. The implementation leverages two key features from tar: https://man7.org/linux/man-pages/man1/tar.1.html

1. "-C": change the working directory of tar to the config directory before packaging. This ensures the paths in tarball are agnostic to the working space directory path used by the agent where the action will run.
2. "--xform": tranform the file path based on sed-style expression during packaging. This enables file path transformation to support relative or absolute paths.

**Action metadata changes**
Introduce a new optional input parameter 'transformed-nginx-config-directory-path' to allow users to overwrite the absolute path of the config directory to the NGINX for Azure deployment. If not specified, relative paths to the config directory will be used for the files.

**Testing**
Testing has been done for a config directory containing child config and njs files in nested subdirectories:
1. Using relative paths
-- Config: https://github.com/bangbingsyb/nginx-config-github-composite-action/tree/main/config-relative-paths
-- Action result: https://github.com/bangbingsyb/nginx-config-github-composite-action/actions/runs/2311611077
3. Using absolute paths
-- Config: https://github.com/bangbingsyb/nginx-config-github-composite-action/tree/main/config-absolute-paths
-- Action result: https://github.com/bangbingsyb/nginx-config-github-composite-action/actions/runs/2311600337
