### PR TITLE
Update action version number in sample workflows and minor fixes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # NGINX for Azure Deployment Action
 
-This action supports managing the configuration of an an [NGINX for Azure](https://docs.nginx.com/nginx-for-azure/quickstart/overview/) deployment in a GitHub repository. It enables continuous deployment through GitHub workflows to automatically update the NGINX for Azure deployment when changes are made to the NGINX configuration files stored in the respository.
+This action supports managing the configuration of an [NGINX for Azure](https://docs.nginx.com/nginx-for-azure/quickstart/overview/) deployment in a GitHub repository. It enables continuous deployment through GitHub workflows to automatically update the NGINX for Azure deployment when changes are made to the NGINX configuration files stored in the respository.
 
 ## Connecting to Azure
 
 This action leverages the [Azure Login](https://github.com/marketplace/actions/azure-login) action for authenticating with Azure and performing update to an NGINX for Azure deployment. Two different ways of authentication are supported:
 - [Service principal with secrets](https://docs.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Cwindows#use-the-azure-login-action-with-a-service-principal-secret)
-- [OpenID Connect](https://docs.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Cwindows#use-the-azure-login-action-with-openid-connect) (OIDC) with a Azure service principal using a Federated Identity Credential
+- [OpenID Connect](https://docs.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Cwindows#use-the-azure-login-action-with-openid-connect) (OIDC) with an Azure service principal using a Federated Identity Credential
 
-### Sample workflow that authenticates with Azure using Azure Service Principal with a secret
+### Sample workflow that authenticates with Azure using an Azure service principal with a secret
 
 ```yaml
 # File: .github/workflows/nginxForAzureDeploy.yml
 
-name: Sync the NGINX configuration from the Git repository to an NGINX for Azure deployment
+name: Sync the NGINX configuration from the GitHub repository to an NGINX for Azure deployment
 on:
   push:
     branches:
@@ -28,13 +28,13 @@ jobs:
     - name: 'Checkout repository'
       uses: actions/checkout@v2
 
-    - name: 'Run Azure Login using Azure Service Principal with a secret'
+    - name: 'Run Azure Login using an Azure service principal with a secret'
       uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    - name: 'Sync the NGINX configuration from the Git repository to the NGINX for Azure deployment'
-      uses: nginxinc/nginx-for-azure-deploy-action@v1
+    - name: 'Sync the NGINX configuration from the GitHub repository to the NGINX for Azure deployment'
+      uses: nginxinc/nginx-for-azure-deploy-action@v0.1.0
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         resource-group-name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
@@ -49,7 +49,7 @@ jobs:
 ```yaml
 # File: .github/workflows/nginxForAzureDeploy.yml
 
-name: Sync the NGINX configuration from the Git repository to an NGINX for Azure deployment
+name: Sync the NGINX configuration from the GitHub repository to an NGINX for Azure deployment
 on:
   push:
     branches:
@@ -75,8 +75,8 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: 'Sync the NGINX configuration from the Git repository to the NGINX for Azure deployment'
-      uses: nginxinc/nginx-for-azure-deploy-action@v1
+    - name: 'Sync the NGINX configuration from the GitHub repository to the NGINX for Azure deployment'
+      uses: nginxinc/nginx-for-azure-deploy-action@v0.1.0
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         resource-group-name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
@@ -87,11 +87,11 @@ jobs:
 ```
 ## Handling NGINX configuration file paths
 
-To facilitate the migration of the existing NGINX configuration, NGINX for Azure supports multiple-files configuration with each file uniquely identified by a file path, just like how NGINX configuration files are created and used in a self-hosting machine. An NGINX configuration file can include another file using the [include directive](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/). The file path used in an include directive can either be an absolute path or a relative path to the [prefix path](https://www.nginx.com/resources/wiki/start/topics/tutorials/installoptions/).
+To facilitate the migration of the existing NGINX configuration, NGINX for Azure supports multiple-files configuration with each file uniquely identified by a file path, just like how NGINX configuration files are created and used in a self-hosting machine. An NGINX configuration file can include another file using the [include directive](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/). The file path used in an `include` directive can either be an absolute path or a relative path to the [prefix path](https://www.nginx.com/resources/wiki/start/topics/tutorials/installoptions/).
 
-The following example shows two NGINX configuration files inside the `/etc/nginx` directory on disk are copied and stored in the a GitHub respository under its `config` directory.
+The following example shows two NGINX configuration files inside the `/etc/nginx` directory on disk are copied and stored in a GitHub respository under its `config` directory.
 
-| File path on disk                    | File path in respository          |
+| File path on disk                    | File path in the respository      |
 |--------------------------------------|-----------------------------------|
 | /etc/nginx/nginx.conf                | /config/nginx.conf                |
 | /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf |
@@ -99,8 +99,8 @@ The following example shows two NGINX configuration files inside the `/etc/nginx
 To use this action to sync the configuration files from this example, the directory path relative to the GitHub repository root `config/` is set to the action's input `nginx-config-directory-path` for the action to find and package the configuration files. The root file `nginx.conf` is set to the input `nginx-root-config-file`.
 
 ```yaml
-    - name: 'Sync the NGINX configuration from the Git repository to the NGINX for Azure deployment'
-      uses: nginxinc/nginx-for-azure-deploy-action@v1
+    - name: 'Sync the NGINX configuration from the GitHub repository to the NGINX for Azure deployment'
+      uses: nginxinc/nginx-for-azure-deploy-action@v0.1.0
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         resource-group-name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
@@ -111,10 +111,10 @@ To use this action to sync the configuration files from this example, the direct
 
 By default, the action uses a file's relative path to `nginx-config-directory-path` in the respository as the file path in the NGINX for Azure deployment.
 
-| File path on disk                    | File path in respository          | File path in NGINX for Azure |
-|--------------------------------------|-----------------------------------|------------------------------|
-| /etc/nginx/nginx.conf                | /config/nginx.conf                | nginx.conf                   |
-| /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf | sites-enabled/mysite.conf    |
+| File path on disk                    | File path in the respository      | File path in the NGINX for Azure deployment |
+|--------------------------------------|-----------------------------------|---------------------------------------------|
+| /etc/nginx/nginx.conf                | /config/nginx.conf                | nginx.conf                                  |
+| /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf | sites-enabled/mysite.conf                   |
 
 The default file path handling works for the case of using relative paths in `include` directives, for example, if the root `nginx.conf` references `mysite.conf` using:
 
@@ -132,7 +132,7 @@ The action supports an optional input `transformed-nginx-config-directory-path` 
 
 ```yaml
     - name: 'Sync the NGINX configuration from the Git repository to the NGINX for Azure deployment'
-      uses: nginxinc/nginx-for-azure-deploy-action@v1
+      uses: nginxinc/nginx-for-azure-deploy-action@v0.1.0
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         resource-group-name: ${{ secrets.AZURE_RESOURCE_GROUP_NAME }}
@@ -143,7 +143,7 @@ The action supports an optional input `transformed-nginx-config-directory-path` 
 ```
 The transformed paths of the two configuration files in the NGINX for Azure deployment are summarized in the following table
 
-| File path on disk                    | File path in respository          | File path in NGINX for Azure         |
-|--------------------------------------|-----------------------------------|--------------------------------------|
-| /etc/nginx/nginx.conf                | /config/nginx.conf                | /etc/nginx/nginx.conf                |
-| /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf | /etc/nginx/sites-enabled/mysite.conf |
+| File path on disk                    | File path in the respository      | File path in the NGINX for Azure deployment |
+|--------------------------------------|-----------------------------------|---------------------------------------------|
+| /etc/nginx/nginx.conf                | /config/nginx.conf                | /etc/nginx/nginx.conf                       |
+| /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf | /etc/nginx/sites-enabled/mysite.conf        |


### PR DESCRIPTION
For the initial version of the action, we decide to release it as a preview version v0.1.0, as the service is in public preview and all Azure APIs are in preview version as well.

The PR:
- Updated action version to v0.1.0 in all sample workflows in readme.
- A few minor touches in readme to fix typo and other small defects.