### PR TITLE
Updated test deployment name

### DIFF
--- a/.github/workflows/testNginxForAzureDeploy.yml
+++ b/.github/workflows/testNginxForAzureDeploy.yml
@@ -6,7 +6,7 @@ on:
     - cron:  '0 20 * * *'
 
 env:
-  NGINX_DEPLOYMENT_NAME: githhubci-test-dep
+  NGINX_DEPLOYMENT_NAME: github-action-test-dep
   NGINX_TRANSFORMED_CONFIG_DIR_PATH: /etc/nginx/
   NGINX_ROOT_CONFIG_FILE: nginx.conf
   TEST_RESOURCE_GROUP_NAME: testenv-0da38993-workload


### PR DESCRIPTION
Test deployment is currently in a broken state and have not been able to delete it due to marketplace issues.

Will need to update NGINX_DEPLOYMENT_IP secret with new public IP.