### PR TITLE
Updated test workflow to verify certificate update process

### DIFF
--- a/.github/workflows/testNginxForAzureDeploy.yml
+++ b/.github/workflows/testNginxForAzureDeploy.yml
@@ -3,37 +3,47 @@
 name: Test Github action to update NGINX for Azure configurations
 on:
   schedule:
-    - cron:  '0 20 * * *'
+    - cron: "0 20 * * *"
 
 env:
   NGINX_DEPLOYMENT_NAME: github-action-test-dep
   NGINX_TRANSFORMED_CONFIG_DIR_PATH: /etc/nginx/
   NGINX_ROOT_CONFIG_FILE: nginx.conf
   TEST_RESOURCE_GROUP_NAME: testenv-0da38993-workload
+  NGINX_CERT_NAME: github-action-test-crt
+  NGINX_VAULT_NAME: nlbtest-customer
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  Update-NGINX-Configuration:
+  Update-NGINX:
     runs-on: ubuntu-latest
     steps:
-      - name: 'Checkout repository'
+      - name: "Checkout repository"
         uses: actions/checkout@v2
-      - name: 'AZ CLI Login'
+      - name: "AZ CLI Login"
         uses: azure/login@v1
         with:
-            client-id: ${{ secrets.AZURE_CLIENT_ID }}
-            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: 'Update config - single file'
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: "Sync NGINX certificate to NGINX for Azure - single cert"
+        uses: nginxinc/nginx-for-azure-deploy-action@v0.2.0
+        with:
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          resource-group-name: $TEST_RESOURCE_GROUP_NAME
+          nginx-deployment-name: $NGINX_DEPLOYMENT_NAME
+          nginx-certificate-details: '[{"certificateName": "$NGINX_CERT_NAME", "keyvaultSecret": "https://$NGINX_VAULT_NAME.vault.azure.net/secrets/$NGINX_CERT_NAME", "certificateVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_NUMBER/my-cert.crt", "keyVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_NUMBER/my-cert.key"  } ]'
+
+      - name: "Update config - single file"
         shell: bash
         run: |
           sed -i 's/000000/'"$GITHUB_RUN_NUMBER"'/g' test/configs/single/nginx.conf
           cat test/configs/single/nginx.conf
-      - name: 'Sync NGINX configuration to NGINX on Azure instance - single file'
-        uses: nginxinc/nginx-for-azure-deploy-action@v0
+      - name: "Sync NGINX configuration to NGINX for Azure - single file"
+        uses: nginxinc/nginx-for-azure-deploy-action@v0.2.0
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: $TEST_RESOURCE_GROUP_NAME
@@ -41,17 +51,19 @@ jobs:
           nginx-config-directory-path: test/configs/single/
           nginx-root-config-file: $NGINX_ROOT_CONFIG_FILE
           transformed-nginx-config-directory-path: $NGINX_TRANSFORMED_CONFIG_DIR_PATH
-      - name: 'Validate config update - single file'
+      - name: "Validate config update - single file"
         shell: bash
         run: |
           wget -O - -o /dev/null http://${{ secrets.NGINX_DEPLOYMENT_IP }} | jq '.request.headers."Github-Run-Id"  | test( "'"$GITHUB_RUN_NUMBER"'")'
-      - name: 'Update config - multi file'
+      - name: "Update config - multi file"
         shell: bash
         run: |
+          sed -i 's/000000/'"$GITHUB_RUN_ID"'/g' test/configs/multi/nginx.conf
+          cat test/configs/single/nginx.conf
           sed -i 's/000000/'"$GITHUB_RUN_ID"'/g' test/configs/multi/conf.d/proxy.conf
           cat test/configs/multi/conf.d/proxy.conf
-      - name: 'Sync NGINX configuration to NGINX on Azure instance - multi file'
-        uses: nginxinc/nginx-for-azure-deploy-action@v0
+      - name: "Sync NGINX configuration to NGINX for Azure - multi file"
+        uses: nginxinc/nginx-for-azure-deploy-action@v0.2.0
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: $TEST_RESOURCE_GROUP_NAME
@@ -59,7 +71,19 @@ jobs:
           nginx-config-directory-path: test/configs/multi/
           nginx-root-config-file: $NGINX_ROOT_CONFIG_FILE
           transformed-nginx-config-directory-path: $NGINX_TRANSFORMED_CONFIG_DIR_PATH
-      - name: 'Validate config update'
+
+      - name: "Validate config update"
         shell: bash
         run: |
           wget -O - -o /dev/null http://${{ secrets.NGINX_DEPLOYMENT_IP }} | jq '.request.headers."Github-Run-Id"  | test( "'"$GITHUB_RUN_ID"'")'
+      - name: "Create cert file"
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            echo "-----BEGIN CERTIFICATE-----" > /tmp/$GITHUB_RUN_ID.tmp
+            az keyvault certificate show --vault-name $NGINX_VAULT_NAME  -n $NGINX_CERT_NAME | jq -r .cer | cat >> /tmp/$GITHUB_RUN_ID.tmp
+            echo "-----END CERTIFICATE-----" >> /tmp/$GITHUB_RUN_ID.tmp
+      - name: "Validate certificate update"
+        shell: bash
+        run: |
+          wget -O - -o /dev/null https://${{ secrets.NGINX_DEPLOYMENT_IP }} --ca-certificate=/tmp/$GITHUB_RUN_ID.tmp | jq '.request.headers."Github-Run-Id"  | test( "'"$GITHUB_RUN_ID"'")'

--- a/test/configs/multi/nginx.conf
+++ b/test/configs/multi/nginx.conf
@@ -14,6 +14,19 @@ http {
             proxy_pass http://app;
             health_check;
         }
+    }
+
+    server {
+        listen 443 ssl default_server;
+        server_name example.com;
         
+        ssl_certificate /etc/nginx/ssl/000000/my-cert.crt;
+        ssl_certificate_key /etc/nginx/ssl/000000/my-cert.key;
+
+        location / {
+            include /etc/nginx/conf.d/proxy.conf;
+            proxy_pass http://app;
+            health_check;
+        }
     }
 }


### PR DESCRIPTION
The change enables the testing of both certificate updates

Changes to test procedure:
   - Bump action versions to 'v0.2.0'
  -  Add update of nginx certificate where we modify the virtual paths with the GITHUB_RUN_ID to ensure each run is uniquely verifiable. This is a long lived certificate in our AKV instance 
   - Add additional sed command to update multi file config w/ GITHUB_RUN_ID in path of certificate
   - Add steps for creating cert file from AKV cert and verifying NGINX endpoint can use cert and returns correct header for GITHUB_RUN_ID


Potential Enhancements:
- Use config update and cert update in tandem
- Perform updates to multiple certificates