### PR TITLE
Bumped tag of action we are using in tests and fixed a few test bugs.

### DIFF
--- a/.github/workflows/testNginxForAzureDeploy.yml
+++ b/.github/workflows/testNginxForAzureDeploy.yml
@@ -36,7 +36,7 @@ jobs:
           sed -i 's/000000/'"$GITHUB_RUN_NUMBER"'/g' test/configs/single/nginx.conf
           cat test/configs/single/nginx.conf
       - name: "Sync NGINX configuration to NGINX for Azure - single file"
-        uses: nginxinc/nginx-for-azure-deploy-action@v0.2.1
+        uses: nginxinc/nginx-for-azure-deploy-action@v0.3.0
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: $TEST_RESOURCE_GROUP_NAME
@@ -56,7 +56,7 @@ jobs:
           sed -i 's/000000/'"$GITHUB_RUN_ID"'/g' test/configs/multi/conf.d/proxy.conf
           cat test/configs/multi/conf.d/proxy.conf
       - name: "Sync NGINX configuration and certificate to NGINX for Azure - multi file"
-        uses: nginxinc/nginx-for-azure-deploy-action@v0.2.1
+        uses: nginxinc/nginx-for-azure-deploy-action@v0.3.0
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: $TEST_RESOURCE_GROUP_NAME
@@ -65,7 +65,7 @@ jobs:
           nginx-config-directory-path: test/configs/multi/
           nginx-root-config-file: $NGINX_ROOT_CONFIG_FILE
           transformed-nginx-config-directory-path: $NGINX_TRANSFORMED_CONFIG_DIR_PATH
-          nginx-certificate-details: '[{"certificateName": "$NGINX_CERT_NAME", "keyvaultSecret": "https://$NGINX_VAULT_NAME.vault.azure.net/secrets/$NGINX_CERT_NAME", "certificateVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_ID/my-cert.crt", "keyVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_ID/my-cert.key"  } ]'
+          nginx-certificates: '[{"certificateName": "$NGINX_CERT_NAME", "keyvaultSecret": "https://$NGINX_VAULT_NAME.vault.azure.net/secrets/$NGINX_CERT_NAME", "certificateVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_ID/my-cert.crt", "keyVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_ID/my-cert.key"  } ]'
 
       - name: "Validate config update"
         shell: bash

--- a/.github/workflows/testNginxForAzureDeploy.yml
+++ b/.github/workflows/testNginxForAzureDeploy.yml
@@ -36,7 +36,7 @@ jobs:
           sed -i 's/000000/'"$GITHUB_RUN_NUMBER"'/g' test/configs/single/nginx.conf
           cat test/configs/single/nginx.conf
       - name: "Sync NGINX configuration to NGINX for Azure - single file"
-        uses: nginxinc/nginx-for-azure-deploy-action@v0.2.0
+        uses: nginxinc/nginx-for-azure-deploy-action@v0.2.1
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: $TEST_RESOURCE_GROUP_NAME
@@ -52,33 +52,30 @@ jobs:
         shell: bash
         run: |
           sed -i 's/000000/'"$GITHUB_RUN_ID"'/g' test/configs/multi/nginx.conf
-          cat test/configs/single/nginx.conf
+          cat test/configs/multi/nginx.conf
           sed -i 's/000000/'"$GITHUB_RUN_ID"'/g' test/configs/multi/conf.d/proxy.conf
           cat test/configs/multi/conf.d/proxy.conf
       - name: "Sync NGINX configuration and certificate to NGINX for Azure - multi file"
-        uses: nginxinc/nginx-for-azure-deploy-action@v0.2.0
+        uses: nginxinc/nginx-for-azure-deploy-action@v0.2.1
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           resource-group-name: $TEST_RESOURCE_GROUP_NAME
           nginx-deployment-name: $NGINX_DEPLOYMENT_NAME
-          nginx-resource-location: "westcentralus"
+          nginx-deployment-location: "westcentralus"
           nginx-config-directory-path: test/configs/multi/
           nginx-root-config-file: $NGINX_ROOT_CONFIG_FILE
           transformed-nginx-config-directory-path: $NGINX_TRANSFORMED_CONFIG_DIR_PATH
-          nginx-certificate-details: '[{"certificateName": "$NGINX_CERT_NAME", "keyvaultSecret": "https://$NGINX_VAULT_NAME.vault.azure.net/secrets/$NGINX_CERT_NAME", "certificateVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_NUMBER/my-cert.crt", "keyVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_NUMBER/my-cert.key"  } ]'
+          nginx-certificate-details: '[{"certificateName": "$NGINX_CERT_NAME", "keyvaultSecret": "https://$NGINX_VAULT_NAME.vault.azure.net/secrets/$NGINX_CERT_NAME", "certificateVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_ID/my-cert.crt", "keyVirtualPath": "/etc/nginx/ssl/$GITHUB_RUN_ID/my-cert.key"  } ]'
 
       - name: "Validate config update"
         shell: bash
         run: |
           wget -O - -o /dev/null http://${{ secrets.NGINX_DEPLOYMENT_IP }} | jq '.request.headers."Github-Run-Id"  | test( "'"$GITHUB_RUN_ID"'")'
-      - name: "Create cert file"
+      - name: "Validate certificate update"
         uses: azure/CLI@v1
         with:
           inlineScript: |
             echo "-----BEGIN CERTIFICATE-----" > /tmp/$GITHUB_RUN_ID.tmp
             az keyvault certificate show --vault-name $NGINX_VAULT_NAME  -n $NGINX_CERT_NAME | jq -r .cer | cat >> /tmp/$GITHUB_RUN_ID.tmp
             echo "-----END CERTIFICATE-----" >> /tmp/$GITHUB_RUN_ID.tmp
-      - name: "Validate certificate update"
-        shell: bash
-        run: |
-          wget -O - -o /dev/null https://${{ secrets.NGINX_DEPLOYMENT_IP }} --ca-certificate=/tmp/$GITHUB_RUN_ID.tmp | jq '.request.headers."Github-Run-Id"  | test( "'"$GITHUB_RUN_ID"'")'
+            wget -O - -o /dev/null https://${{ secrets.NGINX_DEPLOYMENT_IP }} --ca-certificate=/tmp/$GITHUB_RUN_ID.tmp | jq '.request.headers."Github-Run-Id"  | test( "'"$GITHUB_RUN_ID"'")'

--- a/action.yml
+++ b/action.yml
@@ -28,15 +28,15 @@ inputs:
       can be used to overwrite the file paths when the action synchronizes the files to the NGINX for Azure deployment.'
     required: false
     default: ""
-  nginx-certificate-details:
+  nginx-certificates:
     description: 'An array of JSON objects each with keys nginx_cert_name, keyvault_secret, certificate_virtual_path and key_virtual_path. Example: [{"certificateName": "server1", "keyvaultSecret": "https://...", "certificateVirtualPath": "/etc/ssl/certs/server1.crt", "keyVirtualPath": "/etc/ssl/certs/server1.key"  }, {"name": "server2", "keyvaultSecret": "https://...", "certificateVirtualPath": "/etc/ssl/certs/server2.crt", "keyVirtualPath": "/etc/ssl/certs/server2.key"  }] '
     required: false
 runs:
   using: "composite"
   steps:
     - name: "Synchronize NGINX certificate(s) from the Git repository to an NGINX for Azure deployment"
-      run: ${{github.action_path}}/src/deploy-certificate.sh --subscription_id=${{ inputs.subscription-id }} --resource_group_name=${{ inputs.resource-group-name }} --nginx_deployment_name=${{ inputs.nginx-deployment-name }} --nginx_resource_location=${{ inputs.nginx-deployment-location }}  --certificates=${{ toJSON(inputs.nginx-certificate-details) }}
-      if: ${{ inputs.nginx-deployment-location != '' && inputs.nginx-certificate-details != '' }}
+      run: ${{github.action_path}}/src/deploy-certificate.sh --subscription_id=${{ inputs.subscription-id }} --resource_group_name=${{ inputs.resource-group-name }} --nginx_deployment_name=${{ inputs.nginx-deployment-name }} --nginx_resource_location=${{ inputs.nginx-deployment-location }}  --certificates=${{ toJSON(inputs.nginx-certificates) }}
+      if: ${{ inputs.nginx-deployment-location != '' && inputs.nginx-certificates != '' }}
       shell: bash
     - name: "Synchronize NGINX configuration from the Git repository to an NGINX for Azure deployment"
       run: ${{github.action_path}}/src/deploy-config.sh --subscription_id=${{ inputs.subscription-id }} --resource_group_name=${{ inputs.resource-group-name }} --nginx_deployment_name=${{ inputs.nginx-deployment-name }} --config_dir_path=${{ inputs.nginx-config-directory-path }} --root_config_file=${{ inputs.nginx-root-config-file }} --transformed_config_dir_path=${{ inputs.transformed-nginx-config-directory-path }}

--- a/src/deploy-certificate.sh
+++ b/src/deploy-certificate.sh
@@ -54,7 +54,7 @@ then
 fi
 if [[ ! -v certificates ]];
 then
-    echo "Please set 'nginx-certificate-details' ..."
+    echo "Please set 'nginx-certificates' ..."
     exit 1 
 fi
 


### PR DESCRIPTION
- Issue with nginx-resource-location for the certificate update (why is it nginx-resource-location in the script and nginx-deployment-location in the action) 
- Finally was able to test the action off a forked branch: https://github.com/agazeley/nginx-for-azure-deploy-action/actions/runs/3094236325
- Squashed validation of certificate update into one step to reduce time and complexity (no need to specify artifacts to pass).