### PR TITLE
NLB-2475: update NGINXaaS for Azure

### DIFF
--- a/.github/workflows/testNginxForAzureDeploy.yml
+++ b/.github/workflows/testNginxForAzureDeploy.yml
@@ -1,6 +1,6 @@
 # File: .github/workflows/testNginxForAzureDeploy.yml
 
-name: Test Github action to update NGINX for Azure configurations
+name: Test Github action to update NGINX as a Service (NGINXaaS) for Azure configurations
 on:
   schedule:
     - cron: "0 20 * * *"
@@ -35,7 +35,7 @@ jobs:
         run: |
           sed -i 's/000000/'"$GITHUB_RUN_NUMBER"'/g' test/configs/single/nginx.conf
           cat test/configs/single/nginx.conf
-      - name: "Sync NGINX configuration to NGINX for Azure - single file"
+      - name: "Sync NGINX configuration to NGINXaaS for Azure - single file"
         uses: nginxinc/nginx-for-azure-deploy-action@v0.3.1
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -55,7 +55,7 @@ jobs:
           cat test/configs/multi/nginx.conf
           sed -i 's/000000/'"$GITHUB_RUN_ID"'/g' test/configs/multi/conf.d/proxy.conf
           cat test/configs/multi/conf.d/proxy.conf
-      - name: "Sync NGINX configuration and certificate to NGINX for Azure - multi file"
+      - name: "Sync NGINX configuration and certificate to NGINXaaS for Azure - multi file"
         uses: nginxinc/nginx-for-azure-deploy-action@v0.3.1
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# NGINX for Azure Deployment Action
+# NGINXaaS for Azure Deployment Action
 
-This action supports managing the configuration of an [NGINX for Azure](https://docs.nginx.com/nginx-for-azure/quickstart/overview/) deployment in a GitHub repository. It enables continuous deployment through GitHub workflows to automatically update the NGINX for Azure deployment when changes are made to the NGINX configuration files stored in the respository. Additionally, one can update NGINX certificates that are already present in Azure key vault.
+This action supports managing the configuration of an [NGINXaaS for Azure](https://docs.nginx.com/nginxaas/azure/quickstart/overview/) deployment in a GitHub repository. It enables continuous deployment through GitHub workflows to automatically update the NGINXaaS for Azure deployment when changes are made to the NGINX configuration files stored in the repository. Additionally, one can update NGINX certificates that are already present in Azure key vault.
 
 ## Connecting to Azure
 
-This action leverages the [Azure Login](https://github.com/marketplace/actions/azure-login) action for authenticating with Azure and performing update to an NGINX for Azure deployment. Two different ways of authentication are supported:
+This action leverages the [Azure Login](https://github.com/marketplace/actions/azure-login) action for authenticating with Azure and performing update to an NGINXaaS for Azure deployment. Two different ways of authentication are supported:
 - [Service principal with secrets](https://docs.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Cwindows#use-the-azure-login-action-with-a-service-principal-secret)
 - [OpenID Connect](https://docs.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Cwindows#use-the-azure-login-action-with-openid-connect) (OIDC) with an Azure service principal using a Federated Identity Credential
 
@@ -13,7 +13,7 @@ This action leverages the [Azure Login](https://github.com/marketplace/actions/a
 ```yaml
 # File: .github/workflows/nginxForAzureDeploy.yml
 
-name: Sync the NGINX configuration from the GitHub repository to an NGINX for Azure deployment
+name: Sync the NGINX configuration from the GitHub repository to an NGINXaaS for Azure deployment
 on:
   push:
     branches:
@@ -33,7 +33,7 @@ jobs:
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    - name: 'Sync the NGINX configuration from the GitHub repository to the NGINX for Azure deployment'
+    - name: 'Sync the NGINX configuration from the GitHub repository to the NGINXaaS for Azure deployment'
       uses: nginxinc/nginx-for-azure-deploy-action@v0.3.0
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -49,7 +49,7 @@ jobs:
 ```yaml
 # File: .github/workflows/nginxForAzureDeploy.yml
 
-name: Sync the NGINX configuration from the GitHub repository to an NGINX for Azure deployment
+name: Sync the NGINX configuration from the GitHub repository to an NGINXaaS for Azure deployment
 on:
   push:
     branches:
@@ -75,7 +75,7 @@ jobs:
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-    - name: 'Sync the NGINX configuration from the GitHub repository to the NGINX for Azure deployment'
+    - name: 'Sync the NGINX configuration from the GitHub repository to the NGINXaaS for Azure deployment'
       uses: nginxinc/nginx-for-azure-deploy-action@v0.3.0
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -88,19 +88,19 @@ jobs:
 
 ## Handling NGINX configuration file paths
 
-To facilitate the migration of the existing NGINX configuration, NGINX for Azure supports multiple-files configuration with each file uniquely identified by a file path, just like how NGINX configuration files are created and used in a self-hosting machine. An NGINX configuration file can include another file using the [include directive](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/). The file path used in an `include` directive can either be an absolute path or a relative path to the [prefix path](https://www.nginx.com/resources/wiki/start/topics/tutorials/installoptions/).
+To facilitate the migration of the existing NGINX configuration, NGINXaaS for Azure supports multiple-files configuration with each file uniquely identified by a file path, just like how NGINX configuration files are created and used in a self-hosting machine. An NGINX configuration file can include another file using the [include directive](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/). The file path used in an `include` directive can either be an absolute path or a relative path to the [prefix path](https://www.nginx.com/resources/wiki/start/topics/tutorials/installoptions/).
 
-The following example shows two NGINX configuration files inside the `/etc/nginx` directory on disk are copied and stored in a GitHub respository under its `config` directory.
+The following example shows two NGINX configuration files inside the `/etc/nginx` directory on disk are copied and stored in a GitHub repository under its `config` directory.
 
-| File path on disk                    | File path in the respository      |
-|--------------------------------------|-----------------------------------|
+| File path on disk                    | File path in the repository      |
+| ------------------------------------ | --------------------------------- |
 | /etc/nginx/nginx.conf                | /config/nginx.conf                |
 | /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf |
 
 To use this action to sync the configuration files from this example, the directory path relative to the GitHub repository root `config/` is set to the action's input `nginx-config-directory-path` for the action to find and package the configuration files. The root file `nginx.conf` is set to the input `nginx-root-config-file`.
 
 ```yaml
-    - name: 'Sync the NGINX configuration from the GitHub repository to the NGINX for Azure deployment'
+    - name: 'Sync the NGINX configuration from the GitHub repository to the NGINXaaS for Azure deployment'
       uses: nginxinc/nginx-for-azure-deploy-action@v0.3.0
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -110,12 +110,12 @@ To use this action to sync the configuration files from this example, the direct
         nginx-root-config-file: nginx.conf
 ```
 
-By default, the action uses a file's relative path to `nginx-config-directory-path` in the respository as the file path in the NGINX for Azure deployment.
+By default, the action uses a file's relative path to `nginx-config-directory-path` in the repository as the file path in the NGINXaaS for Azure deployment.
 
-| File path on disk                    | File path in the respository      | File path in the NGINX for Azure deployment |
-|--------------------------------------|-----------------------------------|---------------------------------------------|
-| /etc/nginx/nginx.conf                | /config/nginx.conf                | nginx.conf                                  |
-| /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf | sites-enabled/mysite.conf                   |
+| File path on disk                    | File path in the repository      | File path in the NGINXaaS for Azure deployment |
+| ------------------------------------ | --------------------------------- | ---------------------------------------------- |
+| /etc/nginx/nginx.conf                | /config/nginx.conf                | nginx.conf                                     |
+| /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf | sites-enabled/mysite.conf                      |
 
 The default file path handling works for the case of using relative paths in `include` directives, for example, if the root `nginx.conf` references `mysite.conf` using:
 
@@ -129,10 +129,10 @@ For the case of using absolute paths in `include` directives, for example, if th
 include /etc/nginx/sites-enabled/mysite.conf;
 ```
 
-The action supports an optional input `transformed-nginx-config-directory-path` to transform the absolute path of the configuration directory in the NGINX for Azure deployment. The absolute configuration directory path on disk `/etc/nginx/` can be set to `transformed-nginx-config-directory-path` as follows to ensure the configuration files using absolute paths in `include` directives work as expected in the NGINX for Azure deployment.
+The action supports an optional input `transformed-nginx-config-directory-path` to transform the absolute path of the configuration directory in the NGINXaaS for Azure deployment. The absolute configuration directory path on disk `/etc/nginx/` can be set to `transformed-nginx-config-directory-path` as follows to ensure the configuration files using absolute paths in `include` directives work as expected in the NGINXaaS for Azure deployment.
 
 ```yaml
-    - name: 'Sync the NGINX configuration from the Git repository to the NGINX for Azure deployment'
+    - name: 'Sync the NGINX configuration from the Git repository to the NGINXaaS for Azure deployment'
       uses: nginxinc/nginx-for-azure-deploy-action@v0.3.0
       with:
         subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -142,12 +142,12 @@ The action supports an optional input `transformed-nginx-config-directory-path` 
         nginx-root-config-file: nginx.conf
         transformed-nginx-config-directory-path: /etc/nginx/
 ```
-The transformed paths of the two configuration files in the NGINX for Azure deployment are summarized in the following table
+The transformed paths of the two configuration files in the NGINXaaS for Azure deployment are summarized in the following table
 
-| File path on disk                    | File path in the respository      | File path in the NGINX for Azure deployment |
-|--------------------------------------|-----------------------------------|---------------------------------------------|
-| /etc/nginx/nginx.conf                | /config/nginx.conf                | /etc/nginx/nginx.conf                       |
-| /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf | /etc/nginx/sites-enabled/mysite.conf        |
+| File path on disk                    | File path in the repository      | File path in the NGINXaaS for Azure deployment |
+| ------------------------------------ | --------------------------------- | ---------------------------------------------- |
+| /etc/nginx/nginx.conf                | /config/nginx.conf                | /etc/nginx/nginx.conf                          |
+| /etc/nginx/sites-enabled/mysite.conf | /config/sites-enabled/mysite.conf | /etc/nginx/sites-enabled/mysite.conf           |
 
 ## Handling NGINX certificates
 
@@ -164,7 +164,7 @@ Since certificates are secrets, it is assumed they are stored in Azure key vault
 See the example below
 
 ```yaml
-- name: "Sync NGINX certificates to NGINX for Azure"
+- name: "Sync NGINX certificates to NGINXaaS for Azure"
         uses: nginxinc/nginx-for-azure-deploy-action@v0.3.0
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -177,7 +177,7 @@ See the example below
 ## Handling NGINX configuration and certificates
 
 ```yaml
- - name: "Sync NGINX configuration- multi file and certificate to NGINX for Azure"
+ - name: "Sync NGINX configuration- multi file and certificate to NGINXaaS for Azure"
         uses: nginxinc/nginx-for-azure-deploy-action@v0.3.0
         with:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,14 @@
-name: "NGINX For Azure Deployment Sync"
-description: "The action synchronizes NGINX configuration from a Git repository and/or certificates already on Azure keyvault to an NGINX for Azure deployment"
+name: "NGINXaaS for Azure Deployment Sync"
+description: "The action synchronizes NGINX configuration from a Git repository and/or certificates already on Azure keyvault to an NGINXaaS for Azure deployment"
 inputs:
   subscription-id:
-    description: "The Azure subscription ID of the NGINX for Azure deployment."
+    description: "The Azure subscription ID of the NGINXaaS for Azure deployment."
     required: true
   resource-group-name:
-    description: "The resource group of the NGINX for Azure deployment."
+    description: "The resource group of the NGINXaaS for Azure deployment."
     required: true
   nginx-deployment-name:
-    description: "The name of the NGINX for Azure deployment."
+    description: "The name of the NGINXaaS for Azure deployment."
     required: true
   nginx-deployment-location:
     description: "The location where the NGINX deployment is located. Example westcentralus"
@@ -23,9 +23,9 @@ inputs:
     default: "nginx.conf"
   transformed-nginx-config-directory-path:
     description: >
-      'The transformed absolute path of the NGINX configuration directory in NGINX for Azure deployment, example: "/etc/nginx/". 
+      'The transformed absolute path of the NGINX configuration directory in NGINXaaS for Azure deployment, example: "/etc/nginx/". 
       If the "include" directive in the NGINX configuration files uses absolute paths, the path transformation 
-      can be used to overwrite the file paths when the action synchronizes the files to the NGINX for Azure deployment.'
+      can be used to overwrite the file paths when the action synchronizes the files to the NGINXaaS for Azure deployment.'
     required: false
     default: ""
   nginx-certificates:
@@ -34,11 +34,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: "Synchronize NGINX certificate(s) from the Git repository to an NGINX for Azure deployment"
+    - name: "Synchronize NGINX certificate(s) from the Git repository to an NGINXaaS for Azure deployment"
       run: ${{github.action_path}}/src/deploy-certificate.sh --subscription_id=${{ inputs.subscription-id }} --resource_group_name=${{ inputs.resource-group-name }} --nginx_deployment_name=${{ inputs.nginx-deployment-name }} --nginx_resource_location=${{ inputs.nginx-deployment-location }}  --certificates=${{ toJSON(inputs.nginx-certificates) }}
       if: ${{ inputs.nginx-deployment-location != '' && inputs.nginx-certificates != '' }}
       shell: bash
-    - name: "Synchronize NGINX configuration from the Git repository to an NGINX for Azure deployment"
+    - name: "Synchronize NGINX configuration from the Git repository to an NGINXaaS for Azure deployment"
       run: ${{github.action_path}}/src/deploy-config.sh --subscription_id=${{ inputs.subscription-id }} --resource_group_name=${{ inputs.resource-group-name }} --nginx_deployment_name=${{ inputs.nginx-deployment-name }} --config_dir_path=${{ inputs.nginx-config-directory-path }} --root_config_file=${{ inputs.nginx-root-config-file }} --transformed_config_dir_path=${{ inputs.transformed-nginx-config-directory-path }}
       if: ${{ inputs.nginx-config-directory-path != '' }}
       shell: bash

--- a/src/deploy-certificate.sh
+++ b/src/deploy-certificate.sh
@@ -109,13 +109,13 @@ do
     echo "Synchronizing NGINX certificate"
     echo "Subscription ID: $subscription_id"
     echo "Resource group name: $resource_group_name"
-    echo "NGINX for Azure deployment name: $nginx_deployment_name"
-    echo "NGINX for Azure Location: $nginx_resource_location"
+    echo "NGINXaaS for Azure deployment name: $nginx_deployment_name"
+    echo "NGINXaaS for Azure Location: $nginx_resource_location"
     echo "ARM template deployment name: $template_deployment_name"
     echo ""
-    echo "NGINX for Azure cert name: $nginx_cert_name"
-    echo "NGINX for Azure cert file location: $nginx_cert_file"
-    echo "NGINX for Azure key file location: $nginx_key_file"
+    echo "NGINXaaS for Azure cert name: $nginx_cert_name"
+    echo "NGINXaaS for Azure cert file location: $nginx_cert_file"
+    echo "NGINXaaS for Azure key file location: $nginx_key_file"
     echo ""
 
     if [ $do_nginx_arm_deployment -eq 1 ]

--- a/src/deploy-config.sh
+++ b/src/deploy-config.sh
@@ -133,7 +133,7 @@ echo "The base64 encoded NGINX configuration tarball"
 echo "$encoded_config_tarball"
 echo ""
 
-# Synchronize the NGINX configuration tarball to the NGINX for Azure deployment.
+# Synchronize the NGINX configuration tarball to the NGINXaaS for Azure deployment.
 
 uuid="$(cat /proc/sys/kernel/random/uuid)"
 template_file="template-$uuid.json"
@@ -147,7 +147,7 @@ echo ""
 echo "Synchronizing NGINX configuration"
 echo "Subscription ID: $subscription_id"
 echo "Resource group name: $resource_group_name"
-echo "NGINX for Azure deployment name: $nginx_deployment_name"
+echo "NGINXaaS for Azure deployment name: $nginx_deployment_name"
 echo "ARM template deployment name: $template_deployment_name"
 echo ""
 

--- a/src/nginx-for-azure-configuration-template.json
+++ b/src/nginx-for-azure-configuration-template.json
@@ -5,7 +5,7 @@
         "nginxDeploymentName": {
             "type": "string",
             "metadata": {
-                "description": "The name of the NGINX for Azure deployment to synchronize the configuration."
+                "description": "The name of the NGINXaaS for Azure deployment to synchronize the configuration."
             }
         },
         "rootFile": {


### PR DESCRIPTION
the README is updated to only refer to “NGINXaaS” for Azure, not “NGINX for Azure”
descriptions are updated to refer to “NGINXaaS for Azure”, not “NGINX for Azure”
update docs links with new URL
Keep file names, workflow names

